### PR TITLE
Adiciona fin de línea cuando optimiza los svg

### DIFF
--- a/scripts/optimize-svg.js
+++ b/scripts/optimize-svg.js
@@ -73,7 +73,7 @@ const optimizeFile = async function (filepath) {
     //     }
     // }
 
-    fs.writeFile(filepath, result.data, function (err) {
+    fs.writeFile(filepath, result.data + '\n', function (err) {
       if (err) return console.log(err);
     });
   });


### PR DESCRIPTION
Evita la generación de diffs cada vez que se aplica el optimizador en `scripts/optimize-svg.js` cuando ha sido anteriormente editado por un editor que adiciona automáticamente un caracter de fin de línea.