### PR TITLE
Actualiza regla de ESLint para obligar el uso de llaves en todos los bloques de código

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
   ],
   plugins: ['better-styled-components'],
   rules: {
+    curly: ['error'],
     'no-console': ['warn'],
     'no-unused-vars': ['error'],
     'import/newline-after-import': ['warn', { count: 1 }],


### PR DESCRIPTION
Actualiza la regla de ESLint de acuerdo con https://eslint.org/docs/rules/curly, para forzar a que todos los bloques de código estén contenidos entre llaves incluso los que son de una sola sentencia.