### PR TITLE
Cambia la carga de los datos de agreement directamente desde la db

### DIFF
--- a/components/EventCard/index.js
+++ b/components/EventCard/index.js
@@ -7,7 +7,7 @@ const formatDate = date => {
     month: 'long',
   };
 
-  return new window.Date(date).toLocaleDateString('ES-pe', options);
+  return new Date(date).toLocaleDateString('ES-pe', options);
 };
 
 export default function EventCard({ date, title, description, status, url }) {

--- a/components/Home/index.js
+++ b/components/Home/index.js
@@ -1,13 +1,12 @@
 import * as Styled from './styles';
-import { Fragment } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import Footer from 'components/Footer';
 import AgreementCard from 'components/AgreementCard';
 import SignatureCount from 'components/SignatureCount';
-import useSWR from 'swr';
-import fetcher from 'lib/fetcher';
 import EventCard from 'components/EventCard';
+import fetchJson from 'lib/fetchJson';
 
 const LogoList = () => (
   <Styled.Boxlogo>
@@ -32,11 +31,21 @@ const LogoList = () => (
 );
 
 export default function Home(props) {
-  const { data } = useSWR('/api/agreements', fetcher);
-  const agreements = data?.data ?? [];
+  const [agreements, setAgreements] = useState([]);
+  const [events, setEvents] = useState([]);
 
-  const { data: eventData } = useSWR('/api/events', fetcher);
-  const events = eventData?.data.slice(-3).reverse() ?? [];
+  useEffect(() => {
+    (async () => {
+      try {
+        const { data } = await fetchJson('/api/agreements');
+        setAgreements(data);
+        const { data: eventData } = await fetchJson('/api/events');
+        setEvents(eventData.slice(-3).reverse());
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, []);
 
   return (
     <Fragment>

--- a/components/Home/index.js
+++ b/components/Home/index.js
@@ -1,12 +1,11 @@
 import * as Styled from './styles';
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import Footer from 'components/Footer';
 import AgreementCard from 'components/AgreementCard';
 import SignatureCount from 'components/SignatureCount';
 import EventCard from 'components/EventCard';
-import fetchJson from 'lib/fetchJson';
 
 const LogoList = () => (
   <Styled.Boxlogo>
@@ -31,21 +30,8 @@ const LogoList = () => (
 );
 
 export default function Home(props) {
-  const [agreements, setAgreements] = useState([]);
-  const [events, setEvents] = useState([]);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const { data } = await fetchJson('/api/agreements');
-        setAgreements(data);
-        const { data: eventData } = await fetchJson('/api/events');
-        setEvents(eventData.slice(-3).reverse());
-      } catch (e) {
-        console.error(e);
-      }
-    })();
-  }, []);
+  const agreements = props.agreements;
+  const events = props.events?.slice(0, 3);
 
   return (
     <Fragment>
@@ -108,7 +94,7 @@ export default function Home(props) {
                 id={id}
                 title={title}
                 description={description}
-                status={events?.[0]?.status}
+                status={events[events.length - 1]?.status}
               />
             ))}
           </Styled.List>

--- a/pages/api/agreements/index.js
+++ b/pages/api/agreements/index.js
@@ -6,6 +6,11 @@ export const getAgreementsOnly = async () => {
   return await AgreementsSchema.find({});
 };
 
+export const getAgreements = async () => {
+  await connectToDatabase();
+  return await AgreementsSchema.find({}).populate('events');
+};
+
 export default async (req, res) => {
   const { method } = req;
 

--- a/pages/api/agreements/index.js
+++ b/pages/api/agreements/index.js
@@ -17,9 +17,7 @@ export default async (req, res) => {
         const agreements = await AgreementsSchema.find({}).populate('events');
         res.status(200).json({ success: true, data: agreements });
       } catch (error) {
-        res
-          .status(400)
-          .json({ success: false, message: 'Error retrieving data' });
+        res.status(400).json({ success: false, message: error.toString() });
       }
       break;
     default:

--- a/pages/api/events/index.js
+++ b/pages/api/events/index.js
@@ -14,6 +14,12 @@ export const createEvent = async body => {
   return newEvent;
 };
 
+export const getEvents = async () => {
+  await connectToDatabase();
+  const events = await EventsSchema.find({});
+  return events;
+};
+
 export default withSession(async (req, res) => {
   const { method, body } = req;
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,18 @@
 import Home from 'components/Home';
 import { getSignatureCount } from 'pages/api/signatures';
+import { getAgreements } from 'pages/api/agreements';
+import { getEvents } from 'pages/api/events';
 
 export async function getServerSideProps() {
   const signatures = await getSignatureCount();
+  const agreements = await getAgreements();
+  const events = await getEvents();
   return {
-    props: { signatures },
+    props: {
+      signatures: signatures,
+      agreements: JSON.parse(JSON.stringify(agreements)),
+      events: JSON.parse(JSON.stringify(events.reverse())),
+    },
   };
 }
 


### PR DESCRIPTION
A fin de evitar el uso de useSWR y los pedidos constantes hacia a la API por cada render de la página, se cambia a getServerSideProps() con la finalidad de obtener los datos directamente desde la base de datos antes de cargar la página. 

También evita error de conexión (400), identificado al emplear SWR. 