### PR TITLE
Adiciona verificación de estado antes de realizar un POST al backend

### DIFF
--- a/components/Form/index.js
+++ b/components/Form/index.js
@@ -14,6 +14,10 @@ const Form = ({ agreements }) => {
   const updateForm = async event => {
     event.preventDefault();
 
+    if (isLoading) {
+      return;
+    }
+
     setIsLoading(true);
 
     if (!currentAgreement.id) {


### PR DESCRIPTION
Evita peticiones duplicada en caso de interrupción de la petición, añadiendo una validación del estado antes de hacer el llamado a la API.

Closes #49 