### PR TITLE
Adiciona ordenamiento a búsqueda de acuerdos en la base de datos

### DIFF
--- a/pages/api/agreements/index.js
+++ b/pages/api/agreements/index.js
@@ -3,12 +3,12 @@ import AgreementsSchema from 'models/Agreements';
 
 export const getAgreementsOnly = async () => {
   await connectToDatabase();
-  return await AgreementsSchema.find({});
+  return await AgreementsSchema.find({}).sort({ id: 1 });
 };
 
 export const getAgreements = async () => {
   await connectToDatabase();
-  return await AgreementsSchema.find({}).populate('events');
+  return await AgreementsSchema.find({}).sort({ id: 1 }).populate('events');
 };
 
 export default async (req, res) => {
@@ -19,7 +19,9 @@ export default async (req, res) => {
   switch (method) {
     case 'GET':
       try {
-        const agreements = await AgreementsSchema.find({}).populate('events');
+        const agreements = await AgreementsSchema.find({})
+          .sort({ id: 1 })
+          .populate('events');
         res.status(200).json({ success: true, data: agreements });
       } catch (error) {
         res.status(400).json({ success: false, message: error.toString() });


### PR DESCRIPTION
Adiciona ordenamiento para evitar que los acuerdos se muestren en el orden en que se encuentran en la db y mostrarlos en un orden de acuerdo al número de acuerdo.